### PR TITLE
[dart_lsc] Support 1.0.0 version of stable dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+* Support 1.0.0 version of stable dependencies. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## [0.0.3] 
 Updated to use latest version of battery
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: battery_indicator
 description: A battery indicator widget.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/debuggerx01/battery_indicator
 
 dependencies:
   flutter:
     sdk: flutter
-  battery: ^0.3.1+8
+  battery: '>=0.3.1+8 <2.0.0'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).